### PR TITLE
Update prod certificate to use wildcard cert

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,8 +1,8 @@
 proxy:
   host: daedalus.dide.ic.ac.uk
   ssl:
-    certificate: VAULT:secret/daedalus/ssl/production/cert:value
-    key: VAULT:secret/daedalus/ssl/production/key:value
+    certificate: VAULT:secret/daedalus/ssl/jameel_institute_org/cert:value
+    key: VAULT:secret/daedalus/ssl/jameel_institute_org/key:value
 api:
   number_of_workers: 4
 web_app_db:


### PR DESCRIPTION
Tested by deploying on the prod server. It works! https://daedalus.jameel-institute.org/

After deploying, on the prod server, I reverted the file change you see in this PR, so we need to do `git pull` from the server(s) after merging this PR.

This new cert is issued to '*.jameel-institute.org' where before it was to 'daedalus.dide.ic.ac.uk'.

I suppose we should remove or rename the secret/daedalus/ssl/production directory?

This also accidentally fixed https://mrc-ide.myjetbrains.com/youtrack/issue/JIDEA-140/Make-http-on-production-redirect-to-the-correct-domain as a side-effect.

