### PR TITLE
jidea-159 update host

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,5 +1,5 @@
 proxy:
-  host: daedalus.dide.ic.ac.uk
+  host: daedalus.jameel-institute.org
   ssl:
     certificate: VAULT:secret/daedalus/ssl/production/cert:value
     key: VAULT:secret/daedalus/ssl/production/key:value

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -80,7 +80,7 @@ http {
         server_name _;
 
         location / {
-            return 301 https://${HTTP_HOST}:443$request_uri;
+            return 301 https://$host$request_uri;
         }
     }
 }


### PR DESCRIPTION
Update host to jameel institute, and also dynamically use request host when redirecting from http.
 
Proxy update tested on dev: https://daedalus-dev.dide.ic.ac.uk 