### PR TITLE
jidea-197 remove configure api step

### DIFF
--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -13,8 +13,13 @@ class DaedalusConstellation:
         redis_mounts = [constellation.ConstellationMount("daedalus-redis", "/data")]
         redis = constellation.ConstellationContainer("redis", cfg.redis_ref, mounts=redis_mounts)
 
-        # 2. api workers
+        # 2. api
         api_env = {"DAEDALUS_QUEUE_ID": cfg.api_queue_id, "REDIS_CONTAINER_NAME": "daedalus-redis"}
+        api = constellation.ConstellationContainer(
+            "api", cfg.api_ref, environment=api_env, mounts=api_mounts, entrypoint="/usr/local/bin/daedalus.api"
+        )
+
+        # 3. api workers
         api_mounts = [constellation.ConstellationMount("daedalus-model-results", "/daedalus/results")]
         api_workers = constellation.ConstellationService(
             "api-worker",
@@ -23,11 +28,6 @@ class DaedalusConstellation:
             environment=api_env,
             mounts=api_mounts,
             entrypoint="/usr/local/bin/daedalus.api.worker",
-        )
-
-        # 3. api
-        api = constellation.ConstellationContainer(
-            "api", cfg.api_ref, environment=api_env, mounts=api_mounts, entrypoint="/usr/local/bin/daedalus.api"
         )
 
         # 4. web_app_db

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -17,7 +17,12 @@ class DaedalusConstellation:
         api_env = {"DAEDALUS_QUEUE_ID": cfg.api_queue_id, "REDIS_CONTAINER_NAME": "daedalus-redis"}
         api_mounts = [constellation.ConstellationMount("daedalus-model-results", "/daedalus/results")]
         api = constellation.ConstellationContainer(
-            "api", cfg.api_ref, environment=api_env, mounts=api_mounts, entrypoint="/usr/local/bin/daedalus.api"
+            "api",
+            cfg.api_ref,
+            environment=api_env,
+            mounts=api_mounts,
+            configure=self.api_wait,
+            entrypoint="/usr/local/bin/daedalus.api"
         )
 
         # 3. api workers
@@ -80,6 +85,11 @@ class DaedalusConstellation:
     def db_configure(self, container, _):
         print("[web-app-dn] Waiting for db")
         args = ["wait-for-db"]
+        docker_util.exec_safely(container, args)
+
+    def api_wait(self, container, _):
+        print("Waiting for api")
+        args = ["sleep", "5"]
         docker_util.exec_safely(container, args)
 
     def proxy_configure(self, container, cfg):

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -15,12 +15,12 @@ class DaedalusConstellation:
 
         # 2. api
         api_env = {"DAEDALUS_QUEUE_ID": cfg.api_queue_id, "REDIS_CONTAINER_NAME": "daedalus-redis"}
+        api_mounts = [constellation.ConstellationMount("daedalus-model-results", "/daedalus/results")]
         api = constellation.ConstellationContainer(
             "api", cfg.api_ref, environment=api_env, mounts=api_mounts, entrypoint="/usr/local/bin/daedalus.api"
         )
 
         # 3. api workers
-        api_mounts = [constellation.ConstellationMount("daedalus-model-results", "/daedalus/results")]
         api_workers = constellation.ConstellationService(
             "api-worker",
             cfg.api_ref,

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -22,7 +22,7 @@ class DaedalusConstellation:
             environment=api_env,
             mounts=api_mounts,
             configure=self.api_wait,
-            entrypoint="/usr/local/bin/daedalus.api"
+            entrypoint="/usr/local/bin/daedalus.api",
         )
 
         # 3. api workers

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -71,7 +71,7 @@ class DaedalusConstellation:
             args=[cfg.proxy_host, cfg.proxy_ref.name, daedalus_app_url],
         )
 
-        containers = [redis, api_workers, api, web_app_db, web_app, proxy]
+        containers = [redis, api, api_workers, web_app_db, web_app, proxy]
 
         obj = constellation.Constellation(
             "daedalus", cfg.container_prefix, containers, cfg.network, cfg.volumes, data=cfg

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -88,8 +88,9 @@ class DaedalusConstellation:
         docker_util.exec_safely(container, args)
 
     def api_wait(self, container, _):
+        # Give the api a couple of seconds to configure the queue
         print("Waiting for api")
-        args = ["sleep", "5"]
+        args = ["sleep", "2"]
         docker_util.exec_safely(container, args)
 
     def proxy_configure(self, container, cfg):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,6 @@ def test_start_daedalus():
     assert docker_util.volume_exists("daedalus-redis")
     assert docker_util.volume_exists("daedalus-model-results")
     assert docker_util.container_exists("daedalus-redis")
-    assert docker_util.container_exists("daedalus-api-configure")
     assert docker_util.container_exists("daedalus-api")
     assert len(docker_util.containers_matching("daedalus-api-worker", False)) == 1
     assert docker_util.container_exists("daedalus-web-app-db")
@@ -32,7 +31,6 @@ def test_start_daedalus():
     assert not docker_util.volume_exists("daedalus-redis")
     assert not docker_util.volume_exists("daedalus-model-results")
     assert not docker_util.container_exists("daedalus-redis")
-    assert not docker_util.container_exists("daedalus-api-configure")
     assert not docker_util.container_exists("daedalus-api")
     assert len(docker_util.containers_matching("daedalus-api-worker", False)) == 0
     assert not docker_util.container_exists("daedalus-web-app-db")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,20 +1,7 @@
-import math
-import time
-
 from constellation import docker_util
 
 from src.daedalus_deploy.config import DaedalusConfig
 from src.daedalus_deploy.daedalus_constellation import DaedalusConstellation
-
-# TODO: Maybe I don't need this any more!?
-def wait_for_container_matching(prefix, stopped, poll=0.1, timeout=5):
-    found = False
-    for _ in range(math.ceil(timeout / poll)):
-        if len(docker_util.containers_matching(prefix, stopped)) > 0:
-            found = True
-            break
-        time.sleep(poll)
-    return found
 
 
 def test_start_daedalus():
@@ -32,7 +19,6 @@ def test_start_daedalus():
     assert docker_util.container_exists("daedalus-redis")
     assert docker_util.container_exists("daedalus-api")
     assert len(docker_util.containers_matching("daedalus-api-worker", False)) == 1
-    #assert wait_for_container_matching("daedalus-api-worker", False)
     assert docker_util.container_exists("daedalus-web-app-db")
     assert docker_util.container_exists("daedalus-web-app")
     assert docker_util.container_exists("daedalus-proxy")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ from constellation import docker_util
 from src.daedalus_deploy.config import DaedalusConfig
 from src.daedalus_deploy.daedalus_constellation import DaedalusConstellation
 
-
+# TODO: Maybe I don't need this any more!?
 def wait_for_container_matching(prefix, stopped, poll=0.1, timeout=5):
     found = False
     for _ in range(math.ceil(timeout / poll)):
@@ -31,7 +31,8 @@ def test_start_daedalus():
     assert docker_util.volume_exists("daedalus-model-results")
     assert docker_util.container_exists("daedalus-redis")
     assert docker_util.container_exists("daedalus-api")
-    assert wait_for_container_matching("daedalus-api-worker", False)
+    assert len(docker_util.containers_matching("daedalus-api-worker", False)) == 1
+    #assert wait_for_container_matching("daedalus-api-worker", False)
     assert docker_util.container_exists("daedalus-web-app-db")
     assert docker_util.container_exists("daedalus-web-app")
     assert docker_util.container_exists("daedalus-proxy")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,18 @@
 from constellation import docker_util
+import math
 
 from src.daedalus_deploy.config import DaedalusConfig
 from src.daedalus_deploy.daedalus_constellation import DaedalusConstellation
+
+def wait_for_container_matching(prefix, stopped, poll=0.1, timeout=5):
+    found = False
+    for i in range(math.ceil(timeout / poll)):
+        if len(docker_util.containers_matching(prefix, stopped)) > 0:
+            found = True
+            break
+        time.sleep(poll)
+        container.reload()
+    return found
 
 
 def test_start_daedalus():
@@ -18,7 +29,7 @@ def test_start_daedalus():
     assert docker_util.volume_exists("daedalus-model-results")
     assert docker_util.container_exists("daedalus-redis")
     assert docker_util.container_exists("daedalus-api")
-    assert len(docker_util.containers_matching("daedalus-api-worker", False)) == 1
+    assert wait_for_container_matching("daedalus-api-worker", False)
     assert docker_util.container_exists("daedalus-web-app-db")
     assert docker_util.container_exists("daedalus-web-app")
     assert docker_util.container_exists("daedalus-proxy")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 from constellation import docker_util
 import math
+import time
 
 from src.daedalus_deploy.config import DaedalusConfig
 from src.daedalus_deploy.daedalus_constellation import DaedalusConstellation
@@ -11,7 +12,6 @@ def wait_for_container_matching(prefix, stopped, poll=0.1, timeout=5):
             found = True
             break
         time.sleep(poll)
-        container.reload()
     return found
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,13 +1,15 @@
-from constellation import docker_util
 import math
 import time
+
+from constellation import docker_util
 
 from src.daedalus_deploy.config import DaedalusConfig
 from src.daedalus_deploy.daedalus_constellation import DaedalusConstellation
 
+
 def wait_for_container_matching(prefix, stopped, poll=0.1, timeout=5):
     found = False
-    for i in range(math.ceil(timeout / poll)):
+    for _ in range(math.ceil(timeout / poll)):
         if len(docker_util.containers_matching(prefix, stopped)) > 0:
             found = True
             break


### PR DESCRIPTION
Update for no longer needing an ephemeral container to configure the rrq queue.

Tested on daedalus-dev: https://daedalus-dev.dide.ic.ac.uk