### PR TITLE
Add dide domain to cert

### DIFF
--- a/config/fakeproxy.yml
+++ b/config/fakeproxy.yml
@@ -1,5 +1,6 @@
 proxy:
   host: localhost
+  host_alias: test.dide.local
 web_app_db:
   postgres:
     password: changeme

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,5 +1,6 @@
 proxy:
   host: daedalus.jameel-institute.org
+  host_alias: daedalus.dide.ic.ac.uk
 api:
   number_of_workers: 4
 web_app_db:

--- a/src/daedalus_deploy/config.py
+++ b/src/daedalus_deploy/config.py
@@ -45,6 +45,7 @@ class DaedalusConfig:
         proxy_key = "proxy"
         self.proxy_ref = self.get_image_reference(proxy_key, dat)
         self.proxy_host = config.config_string(dat, [proxy_key, "host"])
+        self.proxy_host_alias = config.config_string(dat, [proxy_key, "host_alias"], is_optional=True)
         self.proxy_port_http = config.config_integer(dat, [proxy_key, "port_http"])
         self.proxy_port_https = config.config_integer(dat, [proxy_key, "port_https"])
         self.proxy_logs_location = config.config_string(dat, [proxy_key, "logs_location"])

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -89,7 +89,7 @@ class DaedalusConstellation:
                 constellation.ConstellationBindMount("/var/run/docker.sock", "/var/run/docker.sock"),
             ]
 
-            domain_names= cfg.proxy_host
+            domain_names = cfg.proxy_host
             if cfg.proxy_host_alias:
                 domain_names += f",{cfg.proxy_host_alias}"
 

--- a/src/daedalus_deploy/daedalus_constellation.py
+++ b/src/daedalus_deploy/daedalus_constellation.py
@@ -89,6 +89,10 @@ class DaedalusConstellation:
                 constellation.ConstellationBindMount("/var/run/docker.sock", "/var/run/docker.sock"),
             ]
 
+            domain_names= cfg.proxy_host
+            if cfg.proxy_host_alias:
+                domain_names += f",{cfg.proxy_host_alias}"
+
             acme = constellation.ConstellationContainer(
                 "acme-buddy",
                 cfg.acme_buddy_ref,
@@ -97,7 +101,7 @@ class DaedalusConstellation:
                 environment=acme_env,
                 args=[
                     "--domain",
-                    cfg.proxy_host,
+                    domain_names,
                     "--email",
                     "reside@imperial.ac.uk",
                     "--dns-provider",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,7 @@ def test_proxy(cfg):
     assert cfg.proxy_ref.repo == "ghcr.io/jameel-institute"
     assert cfg.proxy_ref.name == "daedalus-proxy"
     assert cfg.proxy_host == "localhost"
+    assert cfg.proxy_host_alias == "test.dide.local"
     assert cfg.proxy_port_http == 80
     assert cfg.proxy_port_https == 443
     assert cfg.proxy_logs_location == "/var/log/nginx"


### PR DESCRIPTION
This adds an extra name on the LetsEncrypt, so that the same cert will be valid viewed from either daedalus.jameel-institute.org or daedalus.dide.ic.ac.uk (which are the same machine). Acme-buddy supports this with just comma-separated domains on the --domain argument.