### PR TITLE
Increase number of workers from 4 to 8

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,7 +1,7 @@
 proxy:
   host: daedalus.jameel-institute.org
 api:
-  number_of_workers: 4
+  number_of_workers: 8
 web_app_db:
   postgres:
     user: VAULT:secret/daedalus/postgres/dev:user


### PR DESCRIPTION
Now that we have a computer with 8 cores, we can use 8 workers at once.

Historical information: Wes boosted the daedalus machine from 2 to 8 cores earlier today, before I began stress-testing.

My interpretation of my findings from stress-testing was that the reason we were seeing the computer struggle when all N cores were demanded simultaneously, was NOT due to an inherent problem with running N model runs at once, but due to some managerial level of the application (say, the R API, or web app) being memory-limited or not being able to find a core to do any work on.

See comments on https://mrc-ide.myjetbrains.com/youtrack/articles/mrc-A-170/Daedalus-Performance-testing for more details / actual millisecond outputs, to see how this conclusion was reached. In short: staggering the requests by a short period (250ms) noticeably improved throughput, and reduced the rate of 500 errors when doing large (>24) batches.

A reason to instead have N-1 workers instead of N, where N is the number of cores, would be if we want to be really sure we're really robust to receiving quasi-simultaneous requests. However, I'm not very confident that this would help, as I don't know if 'not finding a core' is the limiting factor, or if it's a memory limitation.

I'm open to any other arguments for different numbers of workers.

Relates to https://github.com/jameel-institute/daedalus-performance-testing/pull/1