### PR TITLE
Use GHCR image for daedalus.api instead of buildkite image

### DIFF
--- a/config/daedalus.yml
+++ b/config/daedalus.yml
@@ -16,9 +16,9 @@ redis:
     tag: latest
 api:
   image:
-    repo: mrcide
+    repo: ghcr.io/jameel-institute
     name: daedalus.api
-    tag: latest
+    tag: ghcr # Change target branch 'ghcr' to 'latest' once https://github.com/jameel-institute/daedalus.api/pull/56 is merged
   port: 8001
   queue_id: daedalus-queue
   number_of_workers: 1

--- a/config/daedalus.yml
+++ b/config/daedalus.yml
@@ -18,7 +18,7 @@ api:
   image:
     repo: ghcr.io/jameel-institute
     name: daedalus.api
-    tag: ghcr # Change target branch 'ghcr' to 'latest' once https://github.com/jameel-institute/daedalus.api/pull/56 is merged
+    tag: latest
   port: 8001
   queue_id: daedalus-queue
   number_of_workers: 1

--- a/proxy/bin/reverse-proxy
+++ b/proxy/bin/reverse-proxy
@@ -7,7 +7,7 @@ if [ "$#" -eq 3 ]; then
     export DAEDALUS_APP=$3
 else
     echo "Usage: <hostname> <servername> <daedalusapp>"
-    echo "e.g. docker run ... mrcide/daedalus-proxy:main localhost daedalus-proxy http://daedalus-web-app:3000"
+    echo "e.g. docker run ... ghcr.io/jameel-institute/daedalus-proxy:main localhost daedalus-proxy http://daedalus-web-app:3000"
     exit 1
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,6 @@ exclude_lines = [
 ignore = [
   "T201", # allow print
   "S301", # allow pickle
-  "TRY002" # allow Exception
+  "TRY002", # allow Exception
+  "PLW1508", # allow environment variable to be set to 0
 ]

--- a/src/daedalus_deploy/cli.py
+++ b/src/daedalus_deploy/cli.py
@@ -97,7 +97,7 @@ def main(argv=None):
     constellation = DaedalusConstellation(cfg, use_vault)
 
     if args.get("remove_volumes"):
-        print("WARNING! THIS WILL REMOVE ALL VOLUMES CAUSING " "IRREVERSIBLE DATA LOSS!")
+        print("WARNING! THIS WILL REMOVE ALL VOLUMES CAUSING IRREVERSIBLE DATA LOSS!")
         if input("Do you want to continue? [yes/no] ") != "yes":
             print("Not continuing")
             return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,7 +28,7 @@ def test_redis(cfg):
 def test_api(cfg):
     assert cfg.api_queue_id == "daedalus-queue"
     assert cfg.api_number_of_workers == 1
-    assert cfg.api_ref.repo == "mrcide"
+    assert cfg.api_ref.repo == "ghcr.io/jameel-institute"
     assert cfg.api_ref.name == "daedalus.api"
     assert cfg.api_port == 8001
 


### PR DESCRIPTION
Depends on https://github.com/jameel-institute/daedalus.api/pull/56 - which is now merged

This branch of daedalus-deploy has been used on staging to do a successful deployment (to dev site), showing the correct version of the API in the 'about' page.